### PR TITLE
[ADD] Agent Selection Page

### DIFF
--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 import com.immobylette.appmobile.agent.selection.AgentSelectionViewModel
 import com.immobylette.appmobile.agent.selection.agentSelectionNavigation
 import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
@@ -17,6 +18,8 @@ import com.immobylette.appmobile.utils.LocationHelper
 
 class MainActivity : ComponentActivity() {
     private val currentPropertyViewModel by viewModels<CurrentPropertyViewModel>()
+
+    private val currentAgentViewModel by viewModels<CurrentAgentViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
 
@@ -35,7 +38,8 @@ class MainActivity : ComponentActivity() {
                 ){
                     agentSelectionNavigation(
                         agentSelectionViewModel = agentSelectionViewModel,
-                        onNavigateToAgentSelected = { navController.navigate("property-selection") }
+                        currentAgentViewModel = currentAgentViewModel,
+                        onNavigateToAgentSelected = { }, // TODO redirect to loading page
                     )
 
                     propertySelectionNavigation(

--- a/app/src/main/java/com/immobylette/appmobile/agent/current/CurrentAgentViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/current/CurrentAgentViewModel.kt
@@ -1,0 +1,16 @@
+package com.immobylette.appmobile.agent.current
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.State
+import androidx.lifecycle.ViewModel
+import java.util.UUID
+
+class CurrentAgentViewModel : ViewModel() {
+    private val _currentAgent = mutableStateOf(UUID.randomUUID())
+    val currentAgent: State<UUID>
+        get() = _currentAgent
+
+    fun setCurrentAgent(agent: UUID) {
+        _currentAgent.value = agent
+    }
+}

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentListState.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentListState.kt
@@ -1,0 +1,5 @@
+package com.immobylette.appmobile.agent.selection
+
+data class AgentListState (
+    val agentList: List<AgentState> = listOf()
+)

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentMapper.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentMapper.kt
@@ -1,0 +1,11 @@
+package com.immobylette.appmobile.agent.selection
+
+import com.immobylette.appmobile.data.dto.ThirdPartyDto
+import java.net.URL
+
+fun ThirdPartyDto.toAgentState() = AgentState(
+    id = id,
+    name = name,
+    surname = surname,
+    photo = URL("https://picsum.photos/200/300")
+)

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionNavigation.kt
@@ -1,37 +1,30 @@
 package com.immobylette.appmobile.agent.selection
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.getValue
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.immobylette.appmobile.ui.shared.component.GraphicFooter
-import com.immobylette.appmobile.ui.shared.component.Logo
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 
 const val agentSelectionRoute = "agent-selection"
 
 fun NavGraphBuilder.agentSelectionNavigation(
     agentSelectionViewModel: AgentSelectionViewModel,
+    currentAgentViewModel: CurrentAgentViewModel,
     onNavigateToAgentSelected: () -> Unit,
 ) {
-
     composable(agentSelectionRoute) {
-        // Get the state from viewModel
-
-        // Place the page below
-        Surface {
-            //GraphicFooter()
-            Box(
-                contentAlignment = Alignment.Center, // Centre le contenu à l'intérieur de la Box
-                modifier = Modifier.fillMaxSize() // La Box remplit toute la taille de l'écran
-            ) {
-                Logo();
-            }
-
-        }
+        val state: AgentListState by agentSelectionViewModel.state.collectAsStateWithLifecycle()
+        AgentSelectionPage(
+            state = state,
+            fetchAgentList = agentSelectionViewModel::fetchAgentList,
+            setCurrentAgent = currentAgentViewModel::setCurrentAgent,
+            onNavigateToAgentSelected = onNavigateToAgentSelected
+        )
     }
 }
 
-// Place navigation functions below
+fun NavController.navigateToAgentSelection() {
+    navigate(agentSelectionRoute)
+}

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionPage.kt
@@ -85,7 +85,7 @@ fun AgentRow(
         items(agentList) { agent: AgentState ->
             Agent(
                 url = agent.photo,
-                name = agent.surname,
+                name = agent.name,
                 modifier = Modifier.padding(30.dp).width(150.dp).height(agentListHeight.dp),
                 onClick = {
                     setCurrentAgent(agent.id)

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionPage.kt
@@ -1,0 +1,98 @@
+package com.immobylette.appmobile.agent.selection
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.immobylette.appmobile.R
+import com.immobylette.appmobile.ui.shared.component.Agent
+import com.immobylette.appmobile.ui.shared.component.GraphicFooter
+import com.immobylette.appmobile.ui.shared.component.Logo
+import com.immobylette.appmobile.ui.shared.component.Title
+import java.util.UUID
+import kotlin.math.ceil
+
+@Composable
+fun AgentSelectionPage(
+    state: AgentListState,
+    fetchAgentList: () -> Unit,
+    setCurrentAgent: (agent: UUID) -> Unit,
+    onNavigateToAgentSelected:() -> Unit
+) {
+    val halfNbAgents: Int = ceil(state.agentList.size.toDouble()/2).toInt()
+    val agentFirstList: List<AgentState> = state.agentList.take(halfNbAgents)
+    val agentSecondList: List<AgentState> = state.agentList.drop(halfNbAgents)
+
+    LaunchedEffect(Unit) {
+        fetchAgentList()
+    }
+
+    Surface {
+        GraphicFooter()
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Logo(
+                size = 250,
+                corner = 45
+            )
+            Title(
+                text = stringResource(id = R.string.label_select_agent))
+            AgentRow(
+                agentList = agentFirstList,
+                setCurrentAgent = setCurrentAgent,
+                onNavigateToAgentSelected = onNavigateToAgentSelected
+            )
+            AgentRow(
+                agentList = agentSecondList,
+                setCurrentAgent = setCurrentAgent,
+                onNavigateToAgentSelected = onNavigateToAgentSelected
+            )
+        }
+    }
+}
+
+
+@Composable
+fun AgentRow(
+    agentList: List<AgentState>,
+    setCurrentAgent: (UUID) -> Unit,
+    onNavigateToAgentSelected: () -> Unit
+) {
+    val agentListHeight = 250
+    LazyHorizontalGrid(
+        rows = GridCells.Adaptive(minSize = agentListHeight.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(agentListHeight.dp)
+            .padding(0.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        items(agentList) { agent: AgentState ->
+            Agent(
+                url = agent.photo,
+                name = agent.surname,
+                modifier = Modifier.padding(30.dp).width(150.dp).height(agentListHeight.dp),
+                onClick = {
+                    setCurrentAgent(agent.id)
+                    println("Navigate call")
+                    onNavigateToAgentSelected()
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionViewModel.kt
@@ -1,8 +1,30 @@
 package com.immobylette.appmobile.agent.selection
 
 import  androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.immobylette.appmobile.data.dto.ThirdPartyDto
+import com.immobylette.appmobile.utils.RetrofitHelper
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 
 class AgentSelectionViewModel: ViewModel() {
+    private val _state = MutableStateFlow(AgentListState())
 
+    val state: StateFlow<AgentListState>
+        get() {
+            return _state.asStateFlow()
+        }
+
+    fun fetchAgentList() {
+        viewModelScope.launch {
+            val agentList = RetrofitHelper.agentService.getAllAgents().map(ThirdPartyDto::toAgentState)
+            _state.update { current ->
+                current.copy(agentList = agentList)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentState.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentState.kt
@@ -1,0 +1,11 @@
+package com.immobylette.appmobile.agent.selection
+
+import java.net.URL
+import java.util.UUID
+
+data class AgentState (
+    val id: UUID,
+    val surname: String,
+    val name: String,
+    val photo: URL
+)

--- a/app/src/main/java/com/immobylette/appmobile/data/service/AgentService.kt
+++ b/app/src/main/java/com/immobylette/appmobile/data/service/AgentService.kt
@@ -1,0 +1,9 @@
+package com.immobylette.appmobile.data.service
+
+import com.immobylette.appmobile.data.dto.ThirdPartyDto
+import retrofit2.http.GET
+
+interface AgentService {
+    @GET("third-parties/agents")
+    suspend fun getAllAgents(): List<ThirdPartyDto>
+}

--- a/app/src/main/java/com/immobylette/appmobile/ui/shared/component/Agent.kt
+++ b/app/src/main/java/com/immobylette/appmobile/ui/shared/component/Agent.kt
@@ -40,16 +40,16 @@ fun Agent(
             painter = rememberAsyncImagePainter(url.toString()),
             contentScale = ContentScale.Crop,
             contentDescription = name,
-            modifier = modifier
+            modifier = Modifier
                 .clip(CircleShape)
                 .fillMaxWidth()
                 .aspectRatio(1f)
                 .clickable(onClick = onClick)
         )
-        Spacer(modifier.height(8.dp))
+        Spacer(Modifier.height(8.dp))
         Text(
             text = name,
-            modifier = modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
             textAlign = TextAlign.Center,
             fontFamily = MaterialTheme.typography.displayMedium.fontFamily,
             fontWeight = FontWeight(1),

--- a/app/src/main/java/com/immobylette/appmobile/ui/shared/component/Title.kt
+++ b/app/src/main/java/com/immobylette/appmobile/ui/shared/component/Title.kt
@@ -20,7 +20,7 @@ fun Title(text: String, modifier: Modifier = Modifier) {
     Text(
         text = text,
         modifier = modifier,
-        fontSize = 20.sp,
+        fontSize = 30.sp,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.primary,
         fontFamily = MaterialTheme.typography.headlineMedium.fontFamily

--- a/app/src/main/java/com/immobylette/appmobile/utils/RetrofitHelper.kt
+++ b/app/src/main/java/com/immobylette/appmobile/utils/RetrofitHelper.kt
@@ -1,6 +1,7 @@
 package com.immobylette.appmobile.utils
 
 import com.immobylette.appmobile.data.service.PropertyService
+import com.immobylette.appmobile.data.service.AgentService
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -14,4 +15,5 @@ object RetrofitHelper {
         .build()
 
     val propertyService: PropertyService = retrofitClient.create(PropertyService::class.java)
+    val agentService: AgentService = retrofitClient.create(AgentService::class.java)
 }


### PR DESCRIPTION
J'ai du faire un truc sombre pour que les agents soient centrés sur les 2 lignes, j'ai fait 2 listes différentes. 
ça rend beau du coup mais les 2 listes sont indépendantes (donc si il y a + d'agents et qu'on doit scroll les 2 listes sont scrollables indépendemment)

Rendu : 
![Screenshot_20240504_013203_Immobylette](https://github.com/Immobylette/immobylette--app-mobile/assets/78427088/856c9283-421c-42ed-a6f0-906859a90c3f)

J'ai repris ce qu'avait fait @patacoing avec le currentPropertyViewModel pour currentAgentViewModel

j'ai fail y'a le commit d'Alexis pour le logo aussi