### PR TITLE
[ADD] confirmation page

### DIFF
--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -10,11 +10,12 @@ import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 import com.immobylette.appmobile.agent.selection.AgentSelectionViewModel
 import com.immobylette.appmobile.agent.selection.agentSelectionNavigation
 import com.immobylette.appmobile.agent.selection.navigateToAgentSelection
+import com.immobylette.appmobile.confirmation.confirmationNavigation
+import com.immobylette.appmobile.confirmation.navigateToConfirmation
 import com.immobylette.appmobile.loading.loadingNavigation
 import com.immobylette.appmobile.loading.navigateToLoadingPage
 import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
 import com.immobylette.appmobile.property.selection.PropertySelectionViewModel
-import com.immobylette.appmobile.property.selection.navigateToConfirmationOfAttendance
 import com.immobylette.appmobile.property.selection.navigateToPropertySelection
 import com.immobylette.appmobile.property.selection.propertySelectionNavigation
 import com.immobylette.appmobile.ui.shared.theme.ImmobyletteappmobileTheme
@@ -54,7 +55,12 @@ class MainActivity : ComponentActivity() {
                         propertySelectionViewModel = propertySelectionViewModel,
                         currentPropertyViewModel = currentPropertyViewModel,
                         onNavigateToChangeAgent = navController::navigateToAgentSelection,
-                        onNavigateToPropertySelected = navController::navigateToConfirmationOfAttendance
+                        onNavigateToPropertySelected = navController::navigateToConfirmation
+                    )
+
+                    confirmationNavigation(
+                        currentPropertyViewModel = currentPropertyViewModel,
+                        onNavigateToConfirmed = {}
                     )
                 }
             }

--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -35,7 +35,6 @@ class MainActivity : ComponentActivity() {
         setContent {
             val agentSelectionViewModel by viewModels<AgentSelectionViewModel>()
             val propertySelectionViewModel by viewModels<PropertySelectionViewModel>()
-            val confirmationViewModel by viewModels<ConfirmationViewModel>()
             val navController = rememberNavController()
 
             ImmobyletteappmobileTheme {
@@ -63,6 +62,7 @@ class MainActivity : ComponentActivity() {
                     confirmationNavigation(
                         currentPropertyViewModel = currentPropertyViewModel,
                         currentInventoryViewModel = currentInventoryViewModel,
+                        currentAgentViewModel = currentAgentViewModel,
                         onNavigateToConfirmed = {}
                     )
                 }

--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -10,13 +10,13 @@ import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 import com.immobylette.appmobile.agent.selection.AgentSelectionViewModel
 import com.immobylette.appmobile.agent.selection.agentSelectionNavigation
 import com.immobylette.appmobile.agent.selection.navigateToAgentSelection
-import com.immobylette.appmobile.confirmation.ConfirmationViewModel
 import com.immobylette.appmobile.confirmation.confirmationNavigation
 import com.immobylette.appmobile.confirmation.navigateToConfirmation
 import com.immobylette.appmobile.loading.loadingNavigation
 import com.immobylette.appmobile.loading.navigateToLoadingPage
 import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
 import com.immobylette.appmobile.property.selection.PropertySelectionViewModel
+import com.immobylette.appmobile.inventory.current.CurrentInventoryViewModel
 import com.immobylette.appmobile.property.selection.navigateToPropertySelection
 import com.immobylette.appmobile.property.selection.propertySelectionNavigation
 import com.immobylette.appmobile.ui.shared.theme.ImmobyletteappmobileTheme
@@ -24,8 +24,8 @@ import com.immobylette.appmobile.utils.LocationHelper
 
 class MainActivity : ComponentActivity() {
     private val currentPropertyViewModel by viewModels<CurrentPropertyViewModel>()
-
     private val currentAgentViewModel by viewModels<CurrentAgentViewModel>()
+    private val currentInventoryViewModel by viewModels<CurrentInventoryViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
 
@@ -61,8 +61,8 @@ class MainActivity : ComponentActivity() {
                     )
 
                     confirmationNavigation(
-                        confirmationViewModel = confirmationViewModel,
                         currentPropertyViewModel = currentPropertyViewModel,
+                        currentInventoryViewModel = currentInventoryViewModel,
                         onNavigateToConfirmed = {}
                     )
                 }

--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -10,6 +10,7 @@ import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 import com.immobylette.appmobile.agent.selection.AgentSelectionViewModel
 import com.immobylette.appmobile.agent.selection.agentSelectionNavigation
 import com.immobylette.appmobile.agent.selection.navigateToAgentSelection
+import com.immobylette.appmobile.confirmation.ConfirmationViewModel
 import com.immobylette.appmobile.confirmation.confirmationNavigation
 import com.immobylette.appmobile.confirmation.navigateToConfirmation
 import com.immobylette.appmobile.loading.loadingNavigation
@@ -35,6 +36,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val agentSelectionViewModel by viewModels<AgentSelectionViewModel>()
             val propertySelectionViewModel by viewModels<PropertySelectionViewModel>()
+            val confirmationViewModel by viewModels<ConfirmationViewModel>()
             val navController = rememberNavController()
 
             ImmobyletteappmobileTheme {
@@ -60,6 +62,7 @@ class MainActivity : ComponentActivity() {
                     )
 
                     confirmationNavigation(
+                        confirmationViewModel = confirmationViewModel,
                         currentPropertyViewModel = currentPropertyViewModel,
                         currentInventoryViewModel = currentInventoryViewModel,
                         currentAgentViewModel = currentAgentViewModel,

--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -10,6 +10,7 @@ import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 import com.immobylette.appmobile.agent.selection.AgentSelectionViewModel
 import com.immobylette.appmobile.agent.selection.agentSelectionNavigation
 import com.immobylette.appmobile.agent.selection.navigateToAgentSelection
+import com.immobylette.appmobile.confirmation.ConfirmationViewModel
 import com.immobylette.appmobile.confirmation.confirmationNavigation
 import com.immobylette.appmobile.confirmation.navigateToConfirmation
 import com.immobylette.appmobile.loading.loadingNavigation
@@ -34,6 +35,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val agentSelectionViewModel by viewModels<AgentSelectionViewModel>()
             val propertySelectionViewModel by viewModels<PropertySelectionViewModel>()
+            val confirmationViewModel by viewModels<ConfirmationViewModel>()
             val navController = rememberNavController()
 
             ImmobyletteappmobileTheme {
@@ -59,6 +61,7 @@ class MainActivity : ComponentActivity() {
                     )
 
                     confirmationNavigation(
+                        confirmationViewModel = confirmationViewModel,
                         currentPropertyViewModel = currentPropertyViewModel,
                         onNavigateToConfirmed = {}
                     )

--- a/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/agent/selection/AgentSelectionPage.kt
@@ -89,7 +89,6 @@ fun AgentRow(
                 modifier = Modifier.padding(30.dp).width(150.dp).height(agentListHeight.dp),
                 onClick = {
                     setCurrentAgent(agent.id)
-                    println("Navigate call")
                     onNavigateToAgentSelected()
                 }
             )

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
@@ -1,0 +1,24 @@
+package com.immobylette.appmobile.confirmation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
+
+const val confirmationRoute = "confirmation"
+
+fun NavGraphBuilder.confirmationNavigation(
+    currentPropertyViewModel: CurrentPropertyViewModel,
+    onNavigateToConfirmed: () -> Unit,
+) {
+    composable(confirmationRoute) {
+        ConfirmationPage (
+            onNavigateToConfirmed = onNavigateToConfirmed,
+            getTenant = currentPropertyViewModel::getTenant
+        )
+    }
+}
+
+fun NavController.navigateToConfirmation(){
+    navigate(confirmationRoute)
+}

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
@@ -10,6 +10,7 @@ import com.immobylette.appmobile.inventory.current.CurrentInventoryViewModel
 const val confirmationRoute = "confirmation"
 
 fun NavGraphBuilder.confirmationNavigation(
+    confirmationViewModel: ConfirmationViewModel,
     currentPropertyViewModel: CurrentPropertyViewModel,
     currentInventoryViewModel: CurrentInventoryViewModel,
     currentAgentViewModel: CurrentAgentViewModel,
@@ -20,8 +21,10 @@ fun NavGraphBuilder.confirmationNavigation(
             onNavigateToConfirmed = {
                 val propertyId = currentPropertyViewModel.getId()
                 val agentId = currentAgentViewModel.currentAgent.value
-                currentInventoryViewModel.startInventory(propertyId, agentId)
-                onNavigateToConfirmed()
+                confirmationViewModel.startInventory(propertyId, agentId) {
+                    currentInventoryViewModel.changeCurrentInventory(it)
+                    onNavigateToConfirmed()
+                }
             },
             getTenant = currentPropertyViewModel::getTenant
         )

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
@@ -8,12 +8,17 @@ import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
 const val confirmationRoute = "confirmation"
 
 fun NavGraphBuilder.confirmationNavigation(
+    confirmationViewModel: ConfirmationViewModel,
     currentPropertyViewModel: CurrentPropertyViewModel,
     onNavigateToConfirmed: () -> Unit,
 ) {
     composable(confirmationRoute) {
         ConfirmationPage (
-            onNavigateToConfirmed = onNavigateToConfirmed,
+            onNavigateToConfirmed = {
+                val propertyId = currentPropertyViewModel.getId()
+                confirmationViewModel.startInventory(propertyId)
+                onNavigateToConfirmed()
+            },
             getTenant = currentPropertyViewModel::getTenant
         )
     }

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
@@ -3,6 +3,7 @@ package com.immobylette.appmobile.confirmation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.immobylette.appmobile.agent.current.CurrentAgentViewModel
 import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
 import com.immobylette.appmobile.inventory.current.CurrentInventoryViewModel
 
@@ -11,13 +12,15 @@ const val confirmationRoute = "confirmation"
 fun NavGraphBuilder.confirmationNavigation(
     currentPropertyViewModel: CurrentPropertyViewModel,
     currentInventoryViewModel: CurrentInventoryViewModel,
+    currentAgentViewModel: CurrentAgentViewModel,
     onNavigateToConfirmed: () -> Unit,
 ) {
     composable(confirmationRoute) {
         ConfirmationPage (
             onNavigateToConfirmed = {
                 val propertyId = currentPropertyViewModel.getId()
-                currentInventoryViewModel.startInventory(propertyId)
+                val agentId = currentAgentViewModel.currentAgent.value
+                currentInventoryViewModel.startInventory(propertyId, agentId)
                 onNavigateToConfirmed()
             },
             getTenant = currentPropertyViewModel::getTenant

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
@@ -4,19 +4,20 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.immobylette.appmobile.property.current.CurrentPropertyViewModel
+import com.immobylette.appmobile.inventory.current.CurrentInventoryViewModel
 
 const val confirmationRoute = "confirmation"
 
 fun NavGraphBuilder.confirmationNavigation(
-    confirmationViewModel: ConfirmationViewModel,
     currentPropertyViewModel: CurrentPropertyViewModel,
+    currentInventoryViewModel: CurrentInventoryViewModel,
     onNavigateToConfirmed: () -> Unit,
 ) {
     composable(confirmationRoute) {
         ConfirmationPage (
             onNavigateToConfirmed = {
                 val propertyId = currentPropertyViewModel.getId()
-                confirmationViewModel.startInventory(propertyId)
+                currentInventoryViewModel.startInventory(propertyId)
                 onNavigateToConfirmed()
             },
             getTenant = currentPropertyViewModel::getTenant

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationPage.kt
@@ -1,0 +1,119 @@
+package com.immobylette.appmobile.confirmation
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Scaffold
+import com.immobylette.appmobile.ui.shared.component.GraphicFooter
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.immobylette.appmobile.R
+import com.immobylette.appmobile.ui.shared.component.Button
+import com.immobylette.appmobile.ui.shared.component.Title
+import com.immobylette.appmobile.ui.shared.theme.ImmobyletteappmobileTheme
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun ConfirmationPage(
+    onNavigateToConfirmed: () -> Unit,
+    getTenant: () -> String?
+) {
+    val currentTenant = getTenant()
+    val buttonWidth = 200.dp
+    val activity = (LocalContext.current as? Activity)
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(bottom = 300.dp)
+                .fillMaxWidth()
+                .height(400.dp),
+        ) {
+            Title(text = stringResource(id = R.string.label_confirmation_of_attendance))
+            Spacer(modifier = Modifier.height(50.dp))
+            Scaffold(
+                bottomBar = {
+                    Row(modifier = Modifier.fillMaxWidth()){
+                        Button(
+                            text = stringResource(id = R.string.label_button_quit),
+                            onClick = { activity?.finish() },
+                            hasTwoRoundedCorners = true,
+                            modifier = Modifier.width(buttonWidth),
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Button(
+                            text = stringResource(id = R.string.label_button_confirm),
+                            onClick = onNavigateToConfirmed,
+                            isOnLeftSide = false,
+                            modifier = Modifier.width(buttonWidth),
+                        )
+
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 50.dp)
+                    .clip(RoundedCornerShape(30.dp))
+            ){
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(30.dp))
+                        .fillMaxSize()
+                        .background(Color.White)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(50.dp),
+                    ) {
+                        Row {
+                            Text(text = stringResource(id = R.string.label_denomination))
+                            Spacer(modifier = Modifier.width(20.dp))
+                            Text(text = currentTenant ?: "")
+                        }
+                        Spacer(modifier = Modifier.height(50.dp))
+                        Text(text = stringResource(id = R.string.label_confirmation_message))
+                    }
+                }
+
+            }
+        }
+        GraphicFooter()
+    }
+}
+
+@Preview(showBackground=true, widthDp = 1200, heightDp = 1920)
+@Composable
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+fun ConfirmationPagePreview(){
+    val currentTenant = "John Doe"
+
+    ImmobyletteappmobileTheme {
+
+      ConfirmationPage(
+          onNavigateToConfirmed = {},
+          getTenant = { currentTenant }
+      )
+    }
+
+}

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationViewModel.kt
@@ -1,0 +1,19 @@
+package com.immobylette.appmobile.confirmation
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.immobylette.appmobile.utils.RetrofitHelper
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+class ConfirmationViewModel: ViewModel() {
+    fun startInventory(propertyId: UUID) {
+        viewModelScope.launch {
+            val result = RetrofitHelper.inventoryService.startInventory(propertyId)
+            if (!result.isSuccessful) {
+                Log.e("RequestError", "Error starting inventory")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationViewModel.kt
@@ -1,0 +1,22 @@
+package com.immobylette.appmobile.confirmation
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.immobylette.appmobile.data.dto.AgentDto
+import com.immobylette.appmobile.utils.RetrofitHelper
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+class ConfirmationViewModel: ViewModel() {
+    fun startInventory(propertyId: UUID, agentId: UUID, onInventoryStarted: (UUID) -> Unit) {
+        viewModelScope.launch {
+            val agentDto = AgentDto(agentId)
+            val result = RetrofitHelper.inventoryService.startInventory(propertyId, agentDto)
+            if (!result.isSuccessful) {
+                Log.e("RequestError", "Error starting inventory")
+            }
+            onInventoryStarted(result.body()!!)
+        }
+    }
+}

--- a/app/src/main/java/com/immobylette/appmobile/data/dto/AgentDto.kt
+++ b/app/src/main/java/com/immobylette/appmobile/data/dto/AgentDto.kt
@@ -1,0 +1,7 @@
+package com.immobylette.appmobile.data.dto
+
+import java.util.UUID
+
+data class AgentDto(
+    val agent: UUID
+)

--- a/app/src/main/java/com/immobylette/appmobile/data/service/InventoryService.kt
+++ b/app/src/main/java/com/immobylette/appmobile/data/service/InventoryService.kt
@@ -1,0 +1,11 @@
+package com.immobylette.appmobile.data.service
+
+import retrofit2.Response
+import retrofit2.http.POST
+import retrofit2.http.Path
+import java.util.UUID
+
+interface InventoryService {
+    @POST("properties/{id}/start")
+    suspend fun startInventory(@Path("id") id: UUID): Response<UUID>
+}

--- a/app/src/main/java/com/immobylette/appmobile/data/service/InventoryService.kt
+++ b/app/src/main/java/com/immobylette/appmobile/data/service/InventoryService.kt
@@ -1,11 +1,13 @@
 package com.immobylette.appmobile.data.service
 
+import com.immobylette.appmobile.data.dto.AgentDto
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.POST
 import retrofit2.http.Path
 import java.util.UUID
 
 interface InventoryService {
     @POST("properties/{id}/start")
-    suspend fun startInventory(@Path("id") id: UUID): Response<UUID>
+    suspend fun startInventory(@Path("id") id: UUID, @Body agent: AgentDto): Response<UUID>
 }

--- a/app/src/main/java/com/immobylette/appmobile/inventory/current/CurrentInventoryViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/inventory/current/CurrentInventoryViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.State
 import com.immobylette.appmobile.utils.RetrofitHelper
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.immobylette.appmobile.data.dto.AgentDto
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -13,12 +14,12 @@ class CurrentInventoryViewModel: ViewModel() {
     private val _currentInventory = mutableStateOf(UUID.randomUUID())
     val currentInventory: State<UUID> get() = _currentInventory
 
-    fun startInventory(propertyId: UUID) {
+    fun startInventory(propertyId: UUID, agentId: UUID) {
         viewModelScope.launch {
-            val result = RetrofitHelper.inventoryService.startInventory(propertyId)
+            val agentDto = AgentDto(agentId)
+            val result = RetrofitHelper.inventoryService.startInventory(propertyId, agentDto)
             if (!result.isSuccessful) {
                 Log.e("RequestError", "Error starting inventory")
-                return
             }
             _currentInventory.value = result.body()
         }

--- a/app/src/main/java/com/immobylette/appmobile/inventory/current/CurrentInventoryViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/inventory/current/CurrentInventoryViewModel.kt
@@ -1,19 +1,26 @@
-package com.immobylette.appmobile.confirmation
+package com.immobylette.appmobile.inventory.current
 
+import androidx.compose.runtime.mutableStateOf
 import android.util.Log
+import androidx.compose.runtime.State
+import com.immobylette.appmobile.utils.RetrofitHelper
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.immobylette.appmobile.utils.RetrofitHelper
 import kotlinx.coroutines.launch
 import java.util.UUID
 
-class ConfirmationViewModel: ViewModel() {
+class CurrentInventoryViewModel: ViewModel() {
+    private val _currentInventory = mutableStateOf(UUID.randomUUID())
+    val currentInventory: State<UUID> get() = _currentInventory
+
     fun startInventory(propertyId: UUID) {
         viewModelScope.launch {
             val result = RetrofitHelper.inventoryService.startInventory(propertyId)
             if (!result.isSuccessful) {
                 Log.e("RequestError", "Error starting inventory")
+                return
             }
+            _currentInventory.value = result.body()
         }
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/inventory/current/CurrentInventoryViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/inventory/current/CurrentInventoryViewModel.kt
@@ -1,27 +1,15 @@
 package com.immobylette.appmobile.inventory.current
 
 import androidx.compose.runtime.mutableStateOf
-import android.util.Log
 import androidx.compose.runtime.State
-import com.immobylette.appmobile.utils.RetrofitHelper
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.immobylette.appmobile.data.dto.AgentDto
-import kotlinx.coroutines.launch
 import java.util.UUID
 
 class CurrentInventoryViewModel: ViewModel() {
     private val _currentInventory = mutableStateOf(UUID.randomUUID())
     val currentInventory: State<UUID> get() = _currentInventory
 
-    fun startInventory(propertyId: UUID, agentId: UUID) {
-        viewModelScope.launch {
-            val agentDto = AgentDto(agentId)
-            val result = RetrofitHelper.inventoryService.startInventory(propertyId, agentDto)
-            if (!result.isSuccessful) {
-                Log.e("RequestError", "Error starting inventory")
-            }
-            _currentInventory.value = result.body()
-        }
+    fun changeCurrentInventory(newInventory: UUID) {
+        _currentInventory.value = newInventory
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/property/current/CurrentPropertyViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/current/CurrentPropertyViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.State
 import androidx.lifecycle.ViewModel
 import com.immobylette.appmobile.property.selection.PropertyState
+import java.util.UUID
 
 class CurrentPropertyViewModel: ViewModel() {
     private val _currentProperty = mutableStateOf(PropertyState())
@@ -15,5 +16,9 @@ class CurrentPropertyViewModel: ViewModel() {
 
     fun getTenant(): String? {
         return _currentProperty.value.currentTenant;
+    }
+
+    fun getId(): UUID {
+        return _currentProperty.value.id;
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/property/current/CurrentPropertyViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/current/CurrentPropertyViewModel.kt
@@ -3,13 +3,17 @@ package com.immobylette.appmobile.property.current
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.State
 import androidx.lifecycle.ViewModel
-import java.util.UUID
+import com.immobylette.appmobile.property.selection.PropertyState
 
 class CurrentPropertyViewModel: ViewModel() {
-    private val _currentProperty = mutableStateOf(UUID.randomUUID())
-    val currentProperty: State<UUID> get() = _currentProperty
+    private val _currentProperty = mutableStateOf(PropertyState())
+    val currentProperty: State<PropertyState> get() = _currentProperty
 
-    fun changeCurrentProperty(property: UUID) {
+    fun changeCurrentProperty(property: PropertyState) {
         _currentProperty.value = property
+    }
+
+    fun getTenant(): String? {
+        return _currentProperty.value.currentTenant;
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionNavigation.kt
@@ -36,7 +36,3 @@ fun NavGraphBuilder.propertySelectionNavigation(
 fun NavController.navigateToPropertySelection(){
     navigate(propertySelectionRoute)
 }
-
-fun NavController.navigateToConfirmationOfAttendance() {
-    //TODO: Navigate to the confirmation of attendance screen
-}

--- a/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionPage.kt
@@ -36,7 +36,7 @@ fun PropertySelectionPage (
     state: PropertyListState,
     fetchPropertyList: () -> Unit,
     fetchProperty: (UUID) -> Unit,
-    saveCurrentProperty: (UUID) -> Unit,
+    saveCurrentProperty: (PropertyState) -> Unit,
     onNavigateToChangeAgent: () -> Unit,
     onNavigateToPropertySelected: () -> Unit
 ) {
@@ -81,8 +81,6 @@ fun PropertySelectionPage (
         }
     }
 
-    //FIXME: Il ne reste plus qu'à trouver un moyen pour fixer le boutton en bas à gauche
-
     Scaffold(
         bottomBar = {
             Button(
@@ -113,7 +111,7 @@ fun PropertySelectionPage (
                             fetchProperty(property.id)
                         },
                     ) {
-                        saveCurrentProperty(property.id)
+                        saveCurrentProperty(property)
                         onNavigateToPropertySelected()
                     }
                     Spacer(modifier = Modifier.height(30.dp))

--- a/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionViewModel.kt
@@ -1,6 +1,6 @@
 package com.immobylette.appmobile.property.selection
 
-import android.widget.Toast
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.immobylette.appmobile.utils.LocationHelper
@@ -43,7 +43,7 @@ class PropertySelectionViewModel: ViewModel() {
                     )
                 }
             }else{
-                Toast.makeText(null, "Error fetching properties", Toast.LENGTH_SHORT).show()
+                Log.e("RequestError", "Error fetching properties")
             }
         }
     }
@@ -76,6 +76,8 @@ class PropertySelectionViewModel: ViewModel() {
                         }
                     )
                 }
+            }else{
+                Log.e("RequestError", "Error fetching property")
             }
         }
     }

--- a/app/src/main/java/com/immobylette/appmobile/utils/RetrofitHelper.kt
+++ b/app/src/main/java/com/immobylette/appmobile/utils/RetrofitHelper.kt
@@ -6,6 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 import com.immobylette.appmobile.BuildConfig
+import com.immobylette.appmobile.data.service.InventoryService
 
 object RetrofitHelper {
 
@@ -16,4 +17,5 @@ object RetrofitHelper {
 
     val propertyService: PropertyService = retrofitClient.create(PropertyService::class.java)
     val agentService: AgentService = retrofitClient.create(AgentService::class.java)
+    val inventoryService: InventoryService = retrofitClient.create(InventoryService::class.java)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,9 @@
     <string name="label_in_progress">En cours</string>
     <string name="label_button_inventory">État des lieux</string>
     <string name="label_button_change_agent">Changer d\'agent</string>
+    <string name="label_confirmation_of_attendance">Confirmation de présence</string>
+    <string name="label_denomination">Madame / Monsieur</string>
+    <string name="label_confirmation_message">Pouvez-vous confirmer votre présence svp ?</string>
+    <string name="label_button_quit">Quitter</string>
+    <string name="label_button_confirm">Confirmer</string>
 </resources>


### PR DESCRIPTION
Modification du sharedViewModel currentProperty pour stocker toute la property au lieu de seulement l'id ==> on a accès au currentTenant qui doit être affiché dans la page de confirmation.

Modifications lorsque les requêtes à l'api ne sont pas successful : on Log.e l'erreur plutôt que un Toast parce que ça ne fonctionne pas