### PR TITLE
[UPDATE] go to property selection after clicking on quit

### DIFF
--- a/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
+++ b/app/src/main/java/com/immobylette/appmobile/MainActivity.kt
@@ -86,14 +86,16 @@ class MainActivity : ComponentActivity() {
                         currentPropertyViewModel = currentPropertyViewModel,
                         currentInventoryViewModel = currentInventoryViewModel,
                         currentAgentViewModel = currentAgentViewModel,
-                        onNavigateToConfirmed = navController::navigateToGoToRoom
+                        onNavigateToConfirmed = navController::navigateToGoToRoom,
+                        onNavigateToPropertySelection = navController::navigateToPropertySelection
                     )
 
                     goToRoomNavigation(
                         goToRoomViewModel = goToRoomViewModel,
                         currentRoomViewModel = currentRoomViewModel,
                         currentInventoryViewModel = currentInventoryViewModel,
-                        onNavigateToRoomElements = navController::navigateToWalls
+                        onNavigateToRoomElements = navController::navigateToWalls,
+                        onNavigateToPropertySelection = navController::navigateToPropertySelection
                     )
 
                     elementsNavigation(
@@ -106,7 +108,8 @@ class MainActivity : ComponentActivity() {
                         onNavigateToTakePicture = navController::navigateToTakePicture,
                         onNavigateToElements = navController::navigateToElements,
                         onNavigateToInventorySummary = { },
-                        onNavigateToCurrentRoom = navController::navigateToGoToRoom
+                        onNavigateToCurrentRoom = navController::navigateToGoToRoom,
+                        onNavigateToPropertySelection = navController::navigateToPropertySelection
                     )
 
                     cameraNavigation(

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationNavigation.kt
@@ -15,6 +15,7 @@ fun NavGraphBuilder.confirmationNavigation(
     currentInventoryViewModel: CurrentInventoryViewModel,
     currentAgentViewModel: CurrentAgentViewModel,
     onNavigateToConfirmed: () -> Unit,
+    onNavigateToPropertySelection: () -> Unit
 ) {
     composable(confirmationRoute) {
         ConfirmationPage (
@@ -33,7 +34,8 @@ fun NavGraphBuilder.confirmationNavigation(
 
                 }
             },
-            getTenant = currentPropertyViewModel::getTenant
+            getTenant = currentPropertyViewModel::getTenant,
+            onNavigateToPropertySelection = onNavigateToPropertySelection
         )
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/confirmation/ConfirmationPage.kt
@@ -38,6 +38,7 @@ import com.immobylette.appmobile.ui.shared.theme.ImmobyletteappmobileTheme
 @Composable
 fun ConfirmationPage(
     onNavigateToConfirmed: () -> Unit,
+    onNavigateToPropertySelection: () -> Unit,
     getTenant: () -> String?
 ) {
     val currentTenant = getTenant()
@@ -107,6 +108,7 @@ fun ConfirmationPage(
             QuitAppPopup(
                 onDismissRequest = { displayModalQuitApp = false },
                 onCancelClicked = { displayModalQuitApp = false },
+                onQuitClicked = onNavigateToPropertySelection
             )
         }
     }
@@ -122,7 +124,8 @@ fun ConfirmationPagePreview(){
 
       ConfirmationPage(
           onNavigateToConfirmed = {},
-          getTenant = { currentTenant }
+          onNavigateToPropertySelection = {},
+          getTenant = { currentTenant },
       )
     }
 

--- a/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionNavigation.kt
@@ -25,6 +25,7 @@ fun NavGraphBuilder.propertySelectionNavigation(
                 state = state,
                 fetchPropertyList = propertySelectionViewModel::fetchPropertyList,
                 fetchProperty = propertySelectionViewModel::fetchProperty,
+                clearPropertyList = propertySelectionViewModel::clearPropertyList,
                 saveCurrentProperty = currentPropertyViewModel::changeCurrentProperty,
                 onNavigateToChangeAgent = onNavigateToChangeAgent,
                 onNavigateToPropertySelected = onNavigateToPropertySelected

--- a/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionPage.kt
@@ -36,6 +36,7 @@ fun PropertySelectionPage (
     state: PropertyListState,
     fetchPropertyList: () -> Unit,
     fetchProperty: (UUID) -> Unit,
+    clearPropertyList: () -> Unit,
     saveCurrentProperty: (PropertyState) -> Unit,
     onNavigateToChangeAgent: () -> Unit,
     onNavigateToPropertySelected: () -> Unit
@@ -65,6 +66,10 @@ fun PropertySelectionPage (
         } else {
             Toast.makeText(context, "Permission Denied", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    LaunchedEffect(Unit) {
+        clearPropertyList()
     }
 
     LaunchedEffect(reachedBottom) {

--- a/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionViewModel.kt
+++ b/app/src/main/java/com/immobylette/appmobile/property/selection/PropertySelectionViewModel.kt
@@ -82,4 +82,8 @@ class PropertySelectionViewModel: ViewModel() {
             }
         }
     }
+
+    fun clearPropertyList() {
+        _state.value = PropertyListState()
+    }
 }

--- a/app/src/main/java/com/immobylette/appmobile/room/elements/ElementsNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/room/elements/ElementsNavigation.kt
@@ -24,7 +24,8 @@ fun NavGraphBuilder.elementsNavigation(
     onNavigateToTakePicture: () -> Unit,
     onNavigateToElements: () -> Unit,
     onNavigateToInventorySummary: () -> Unit,
-    onNavigateToCurrentRoom: () -> Unit
+    onNavigateToCurrentRoom: () -> Unit,
+    onNavigateToPropertySelection: () -> Unit
 ) {
     composable(wallsRoute){
         val walls: ElementListState by wallsViewModel.walls.collectAsStateWithLifecycle()
@@ -45,7 +46,8 @@ fun NavGraphBuilder.elementsNavigation(
             },
             fetchElements = { wallsViewModel.fetchWallList(currentInventoryViewModel.getCurrentInventory()) },
             fetchElement = { elementId: UUID -> wallsViewModel.fetchWall(currentInventoryViewModel.getCurrentInventory(), elementId) },
-            onNavigateToTakePicture = onNavigateToTakePicture
+            onNavigateToTakePicture = onNavigateToTakePicture,
+            onNavigateToPropertySelection = onNavigateToPropertySelection
         )
     }
 
@@ -71,7 +73,8 @@ fun NavGraphBuilder.elementsNavigation(
             },
             fetchElements = { elementsViewModel.fetchElementList(currentInventoryViewModel.getCurrentInventory()) },
             fetchElement = { elementId: UUID -> elementsViewModel.fetchElement(currentInventoryViewModel.getCurrentInventory(), elementId) },
-            onNavigateToTakePicture = onNavigateToTakePicture
+            onNavigateToTakePicture = onNavigateToTakePicture,
+            onNavigateToPropertySelection = onNavigateToPropertySelection
         )
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/room/elements/ElementsPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/room/elements/ElementsPage.kt
@@ -63,7 +63,8 @@ fun ElementsPage(
     setCurrentElement: (ElementState) -> Unit,
     onClickSameState: (ElementState) -> Unit,
     onClickOnNext: () -> Unit,
-    onNavigateToTakePicture: () -> Unit
+    onNavigateToTakePicture: () -> Unit,
+    onNavigateToPropertySelection: () -> Unit
 ){
     var currentPhoto by remember { mutableStateOf(PhotoUrlDto()) }
     var displayModalQuitApp by remember { mutableStateOf(false) }
@@ -203,7 +204,8 @@ fun ElementsPage(
         if (displayModalQuitApp){
             QuitAppPopup(
                 onDismissRequest = { displayModalQuitApp = false },
-                onCancelClicked = { displayModalQuitApp = false }
+                onCancelClicked = { displayModalQuitApp = false },
+                onQuitClicked = onNavigateToPropertySelection
             )
         }
     }
@@ -405,7 +407,8 @@ fun ElementsPagePreview(){
             onNavigateToTakePicture = {},
             onClickSameState = {},
             onClickOnNext = {},
-            setCurrentElement = {}
+            setCurrentElement = {},
+            onNavigateToPropertySelection = {}
         )
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/room/gotoroom/GoToRoomNavigation.kt
+++ b/app/src/main/java/com/immobylette/appmobile/room/gotoroom/GoToRoomNavigation.kt
@@ -15,6 +15,7 @@ fun NavGraphBuilder.goToRoomNavigation(
     currentRoomViewModel: CurrentRoomViewModel,
     currentInventoryViewModel: CurrentInventoryViewModel,
     onNavigateToRoomElements: () -> Unit,
+    onNavigateToPropertySelection: () -> Unit
 ) {
     composable(goToRoomRoute) {
         val state: RoomState by goToRoomViewModel.state.collectAsStateWithLifecycle()
@@ -24,7 +25,8 @@ fun NavGraphBuilder.goToRoomNavigation(
             fetchCurrentRoom = goToRoomViewModel::fetchCurrentRoom,
             setCurrentRoom = currentRoomViewModel::setCurrentRoom,
             getCurrentInventory = currentInventoryViewModel::getCurrentInventory,
-            onNavigateToRoomElements = onNavigateToRoomElements
+            onNavigateToRoomElements = onNavigateToRoomElements,
+            onNavigateToPropertySelection = onNavigateToPropertySelection
         )
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/room/gotoroom/GoToRoomPage.kt
+++ b/app/src/main/java/com/immobylette/appmobile/room/gotoroom/GoToRoomPage.kt
@@ -48,7 +48,8 @@ fun GoToRoomPage(
     fetchCurrentRoom: (id: UUID) -> Unit,
     setCurrentRoom: (room: RoomState) -> Unit,
     getCurrentInventory: () -> UUID,
-    onNavigateToRoomElements:() -> Unit
+    onNavigateToRoomElements:() -> Unit,
+    onNavigateToPropertySelection: () -> Unit
 ) {
     var displayModalQuitApp by remember { mutableStateOf(false) }
     setCurrentRoom(state)
@@ -162,7 +163,8 @@ fun GoToRoomPage(
     if (displayModalQuitApp){
         QuitAppPopup(
             onDismissRequest = { displayModalQuitApp = false },
-            onCancelClicked = { displayModalQuitApp = false }
+            onCancelClicked = { displayModalQuitApp = false },
+            onQuitClicked = onNavigateToPropertySelection
         )
     }
 }

--- a/app/src/main/java/com/immobylette/appmobile/ui/shared/component/QuitAppPopup.kt
+++ b/app/src/main/java/com/immobylette/appmobile/ui/shared/component/QuitAppPopup.kt
@@ -1,7 +1,6 @@
 package com.immobylette.appmobile.ui.shared.component
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import androidx.compose.material3.Text
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -32,10 +30,9 @@ import com.immobylette.appmobile.ui.shared.theme.ImmobyletteappmobileTheme
 fun QuitAppPopup(
     onDismissRequest: () -> Unit,
     onCancelClicked: () -> Unit,
+    onQuitClicked: () -> Unit,
     modifier : Modifier = Modifier
 ) {
-    val activity = (LocalContext.current as? Activity)
-
     AlertDialog(
         onDismissRequest = onDismissRequest,
     ) {
@@ -59,7 +56,7 @@ fun QuitAppPopup(
                         text = stringResource(id = R.string.label_button_confirm),
                         modifier = Modifier.width(150.dp)
                     ) {
-                        activity?.finish()
+                        onQuitClicked()
                     }
                 }
             }
@@ -90,6 +87,7 @@ fun QuitAppPopupPreview(){
         QuitAppPopup(
             onDismissRequest = {},
             onCancelClicked = {},
+            onQuitClicked = {}
         )
     }
 }


### PR DESCRIPTION
J'ai du également ajouter une méthode dans le PropertySelectionViewModel pour pouvoir clear la liste des propriétés parce que si on revient sur la page des properties , la liste n'est pas actualisée et donc on ne voit pas que maintenant un état des lieux est en cours.